### PR TITLE
fix: there is no `initialize-validator` command

### DIFF
--- a/infrastructure/zk/src/contract.ts
+++ b/infrastructure/zk/src/contract.ts
@@ -33,6 +33,7 @@ function updateContractsEnv(deployLog: String, envVars: Array<string>) {
     return updatedContracts;
 }
 
+// TODO(zidong): there is no initialize-validator command. this code will always fail
 export async function initializeValidator(args: any[] = []) {
     await utils.confirmAction();
 
@@ -131,7 +132,8 @@ command
     .action(redeployL1);
 command.command('deploy [deploy-opts...]').allowUnknownOption(true).description('deploy contracts').action(deployL1);
 command.command('build').description('build contracts').action(build);
-command.command('initilize-validator').description('initialize validator').action(initializeValidator);
+// TODO(zidong): this will always silently fail
+// command.command('initilize-validator').description('initialize validator').action(initializeValidator);
 command
     .command('initilize-l1-allow-list-contract')
     .description('initialize L1 allow list contract')

--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -61,7 +61,10 @@ export async function init(skipSubmodulesCheckout: boolean = false) {
     await announced('Running server genesis setup', server.genesisFromSources());
 
     await announced('Deploying L1 contracts', contract.redeployL1([]));
-    await announced('Initializing validator', contract.initializeValidator());
+
+    // TODO(zidong): this will always silently fail
+    // await announced('Initializing validator', contract.initializeValidator());
+
     await announced('Initialize L1 allow list', contract.initializeL1AllowList());
     await announced('Deploying L2 contracts', contract.deployL2());
 }
@@ -79,7 +82,8 @@ export async function reinit() {
     await announced('Building contracts', contract.build());
     await announced('Running server genesis setup', server.genesisFromSources());
     await announced('Deploying L1 contracts', contract.redeployL1([]));
-    await announced('Initializing validator', contract.initializeValidator());
+    // TODO(zidong): this will always silently fail
+    // await announced('Initializing validator', contract.initializeValidator());
     await announced('Initializing L1 Allow list', contract.initializeL1AllowList());
     await announced('Deploying L2 contracts', contract.deployL2());
 }
@@ -90,7 +94,8 @@ export async function lightweightInit() {
     await announced('Clean backups', clean('backups'));
     await announced('Running server genesis setup', server.genesisFromBinary());
     await announced('Deploying L1 contracts', contract.redeployL1([]));
-    await announced('Initializing validator', contract.initializeValidator());
+    // TODO(zidong): this will always silently fail
+    // await announced('Initializing validator', contract.initializeValidator());
     await announced('Initializing L1 Allow list', contract.initializeL1AllowList());
     await announced('Deploying L2 contracts', contract.deployL2());
 }


### PR DESCRIPTION
## Summary

this will silently fail when running `zk init` and output this:

```
------------------------
> Initializing validator
yarn run v1.22.19
$ yarn workspace l1-zksync-contracts initialize-validator
error Command "initialize-validator" not found.                       
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.                                                 
Exit code: 1
Command: /home/ec2-user/.nvm/versions/node/v16.19.1/bin/node
Arguments: /.yarn/releases/yarn-1.22.19.cjs initialize-validator
Directory: /home/ec2-user/snapchain-zksync-era/contracts/ethereum
Output:

info Visit https://yarnpkg.com/en/docs/cli/workspace for documentation about this command.
error Command failed with exit code 1.                                
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
✔ Initializing validator done (984ms)
```

root cause is `contracts/ethereum/package.json` does not have this command